### PR TITLE
Add epic and onboarding issue templates, cut down PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,25 @@
+_Put a short description of what the epic is trying to accomplish here._
+
+Outcome: _Describe the outcome sought_
+
+# Features
+
+*Foundational*
+<!-- Link to related tickets. -->
+
+- [ ] #xx
+- [ ] #xx
+
+*Next*
+<!-- Link to follow on items. -->
+
+- [ ] #xx
+- [ ] #xx
+
+# Stretch Goals
+
+- [ ] Foo
+- [ ] Bar
+
+# Out of scope
+<!-- Describe what is out of scope for the epic.-->

--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -14,3 +14,4 @@ Name: _Name of person being onboarded_
 
 - [ ] [Team Charter](https://docs.google.com/document/d/1xhMKlW8bMcxyF7ipsOYxw1SQYVi-lWPkcDHSUS6miNg/edit), in particular our Github Policy
 - [ ] [Architecture Decision Records](docs/architecture/decisions)
+- [ ] [Github Policy](CONTRIBUTING.md)

--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -1,0 +1,16 @@
+# Developer Onboarding
+
+Name: _Name of person being onboarded_
+
+## Access
+
+- [ ] Add to cloud.gov org and relevant spaces as a SpaceDeveloper
+```cf set-space-role cloud.account@email.gov ORG SPACE SpaceDeveloper
+```
+- [ ] Add to our login.gov sandbox team (`.gov registrar poc`) via the [dashboard](https://dashboard.int.identitysandbox.gov/)
+
+
+## Documents to Review
+
+- [ ] [Team Charter](https://docs.google.com/document/d/1xhMKlW8bMcxyF7ipsOYxw1SQYVi-lWPkcDHSUS6miNg/edit), in particular our Github Policy
+- [ ] [Architecture Decision Records](docs/architecture/decisions)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# <!-- Use the title to describe PR changes in the imperative mood --> #
+
+## 🗣 Description ##
+
+<!-- Describe the "what" of your changes in detail. -->
+<!-- Please link to any relevant issues. -->
+
+## 💭 Motivation and context ##
+
+<!-- Why is this change required? -->
+<!-- What problem does this change solve? How did you solve it? -->
+<!-- Mention any related issue(s) here using appropriate keywords such -->
+<!-- as "closes" or "resolves" to auto-close them on merge. -->


### PR DESCRIPTION
This adds: 

- An epic template based on how @SSPJ created ours for the POC
- An onboarding template for new engineers (this is a great place to keep track of things we are setting up like cloud.gov and login.gov). 
- A trimmed down for now version of CISA's PR template

I will add the CONTRIBUTING.md with Github policy in a separate PR. 