### PR TITLE
add ability to one-off domain lookups, add more error handling

### DIFF
--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -42,6 +42,8 @@ def main(domain):
                 registrar = check_registration(domain_name)
                 full_data.append(domain + [registrar])
 
+    Path("../data").mkdir(exist_ok=True)
+
     with open('../data/registrar_data.csv', 'w') as f:
         writer = csv.writer(f)
         writer.writerow(fields)

--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -24,6 +24,8 @@ def check_registration(name):
     try:
         domain_info = whois.whois(name)
         return domain_info['registrar']
+    except KeyboardInterrupt:
+        sys.exit(1)
     except:
         print(f'Something went wrong with that domain lookup for {name}, continuing...')
 

--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -8,6 +8,8 @@ This script can be run locally to generate data and currently takes some time to
 import csv
 import requests
 import whois
+import argparse
+import sys
 
 GOV_URLS_CSV_URL = "https://raw.githubusercontent.com/GSA/govt-urls/master/1_govt_urls_full.csv"
 
@@ -21,16 +23,32 @@ def check_registration(name):
         domain_info = whois.whois(name)
         return domain_info['registrar']
     except:
-        print('Something went wrong')
+        print(f'Something went wrong with that domain lookup for {name}, continuing...')
 
-full_data = []
-for domain in domains:
-    domain_name = domain[0].lower()
-    if domain_name.endswith('.com') or domain_name.endswith('.edu') or domain_name.endswith('.net'):
-        registrar = check_registration(domain_name)
-        full_data.append(domain + [registrar])
 
-with open('../data/registrar_data.csv', 'w') as f:
-    writer = csv.writer(f)
-    writer.writerow(fields)
-    writer.writerows(full_data)
+def main(domain):
+    full_data = []
+    if domain:
+        registrar = check_registration(domain)
+        print(registrar)
+    else:
+        for idx, domain in enumerate(domains):
+            domain_name = domain[0].lower()
+            if domain_name.endswith('.com') or domain_name.endswith('.edu') or domain_name.endswith('.net'):
+                print(idx)
+                print(domain_name)
+                registrar = check_registration(domain_name)
+                full_data.append(domain + [registrar])
+
+    with open('../data/registrar_data.csv', 'w') as f:
+        writer = csv.writer(f)
+        writer.writerow(fields)
+        writer.writerows(full_data)
+
+
+if __name__ == '__main__':
+    cl = argparse.ArgumentParser(description="This performs ICANN lookups on domains.")
+    cl.add_argument("--domain", help="finds the registrar for a single domain", default=None)
+    args = cl.parse_args()
+
+    sys.exit(main(args.domain))

--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -3,11 +3,13 @@ This script takes each domain in a dataset of non-.gov government domains and lo
 which registrar they are currently registered with. 
 
 This script can be run locally to generate data and currently takes some time to run.
+
+NOTE: This requries python-whois and argparse to be installed. 
 """
 
 import csv
 import requests
-import whois
+import whois # this is python-whois
 import argparse
 import sys
 

--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -12,7 +12,7 @@ import requests
 import whois # this is python-whois
 import argparse
 import sys
-
+from pathlib import Path
 GOV_URLS_CSV_URL = "https://raw.githubusercontent.com/GSA/govt-urls/master/1_govt_urls_full.csv"
 
 data = requests.get(GOV_URLS_CSV_URL).text

--- a/docs/research/scripts/icann_lookup.py
+++ b/docs/research/scripts/icann_lookup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 This script takes each domain in a dataset of non-.gov government domains and looks for 
 which registrar they are currently registered with. 

--- a/docs/research/scripts/response_codes.py
+++ b/docs/research/scripts/response_codes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 This script performs a basic request to each of the domains in the current list of 
 dotgov domains hosted at https://flatgithub.com/cisagov/dotgov-data/blob/main/?filename=current-full.csv


### PR DESCRIPTION
# Update ICANN lookups #

## 🗣 Description ##

@h-m-f-t was having some issues with this script. I've updated it to allow for one off domains like 

```
python3 icann_lookup.py --domain <DOMAIN>
```

to do some testing. I could not replicate issues with the domain that @h-m-f-t was having issues with, and my script completed running without issue. I think that it may be something in a network that prevents hitting certain domains when run locally? Not sure. But I've also added some more info about which domain had an issue before exiting to help debug. 