### PR TITLE
Updates to Product Strategy (simplified and typo) 

### DIFF
--- a/docs/product/phase_one.md
+++ b/docs/product/phase_one.md
@@ -22,14 +22,14 @@ April 2023 - projected month 18F agreement ends
   * Can reduce the number of actors or decisions in a successful flow
   * Upholds a security review process for getting a .gov domain
   * Meets code and accessibility standards + open source policy
-  * Lays the foundation for a “a simple and secure registration process that works to ensure that domains are registered and maintained only by authorized individuals (Dotgov Act)”
+  * Lays the foundation for a “a simple and secure registration process that works to ensure that domains are registered and maintained only by authorized individuals (DOTGOV ACT)”
 * Supporting 1-2 registrant and admin flows with limited improvement and automation, based on value and complexity
 * Has or is ready for an ATO
 * Coordinating and navigating with procurement processes (RFPs and current vendor agreement) 
 
 ### Risks 
 * App may be supported by a combination of manual work and automation, not fully automated
-* Scope creep – we build a system that can’t be ATO’d prior to June or Nov 2023
+* Scope creep – we build a system that can’t be ATO’d prior to Summer or Fall 2023
 * We build out a narrow slice of the system, which may be insufficient for all registrant and administrative use cases
 * We wouldn’t be intentionally and directly focused on or prioritizing improving the registrant / admin experience 
 

--- a/docs/product/product_strategy.md
+++ b/docs/product/product_strategy.md
@@ -15,38 +15,20 @@ _TBD - once we synthesize initial research and align as a product team_
 _TBD - once we synthesize initial research and prioritize areas of need_
 
 ## Short-term Success for .gov
-### Primary:
 * A production-ready, modern .gov registrar that can replace the current system with improved user experience and operational efficiency
   * Built in the open
   * Meeting accessibility and testing standards
 * A plan for developing capacity within the CISA organization going forward
 
-### Secondary
-* Having a clear understanding and definition of current state
-* A plan for new product 
-* A product plan that coordinates with other RFP actions
-
 ## Long-term Success for .gov
-### Primary:
 * Increase the number of governments, currently on non-.gov TLDs, to .gov
 * Develop services to support “the security, privacy, reliability, accessibility, and speed of registered .gov internet domains” (DOTGOV ACT)
 * Sustainable long-term skills and capacity to scale up the program
 
-### Secondary
-* Increase number of domain registrations
-* Reduce time to get an application approved from 20 days to 1-2 business days
-* Increase the percentage of domains which resolve to content
-* Reduce time to ship changes to production
-* Enable the discoverability of government services to the public and to domain registrants (DOTGOV ACT)
-* A “simple and secure” registration process that works to “ensure that domains are registered and maintained only by authorized individuals” (DOTGOV ACT)
-* Active .gov community of practice where members ask and answer questions, provide feedback, and where CISA can communicate with all .gov domain managers
-* Demonstrated commitment to working in the open
-* A clear role for humans or a call center to support registrant use cases
-
-## Problems .gov registrar needs to solve (now)
+## Problems .gov system needs to solve (now)
 _TBD - once we synthesize initial research and align as a product team_
 
-## Problems NextGen doesn’t need to solve (next or later)
+## Problems .gov system doesn’t need to solve (next or later)
 _TBD - once we synthesize initial research and align as a product team_
 
 ## Risks


### PR DESCRIPTION
Cleaned up to be focused on primary focus areas for product strategy and a typo from fork.